### PR TITLE
Support CoffeeScript 1.7.x

### DIFF
--- a/bin/zap
+++ b/bin/zap
@@ -8,8 +8,11 @@ var fs = require('fs')
 
 var coffee
 try {
-	coffee = require('coffee-script')
-} catch (e) {
+	coffee = require('coffee-script/register')
+} catch (e0) {
+ 	try {
+		coffee = require('coffee-script')
+	} catch (e1) {}
 }
 
 if (process.argv[2] === '--one') {


### PR DESCRIPTION
According to [the change log](http://coffeescript.org/#changelog) for CoffeeScript 1.7.0:

> When requiring CoffeeScript files in Node you must now explicitly register the compiler. This can be done with `require 'coffee-script/register'` or `CoffeeScript.register()`.
