### PR TITLE
Do not print newline after test name

### DIFF
--- a/bin/zap
+++ b/bin/zap
@@ -166,7 +166,10 @@ if (process.argv[2] === '--one') {
 			if (tests.length <= 0) { return }
 			var t = tests.shift()
 			var o = testOrder++
-			inOrder(o, function () { console.log(name(t), "... ") })
+			inOrder(o, function () {
+				process.stdout.write(
+					util.format("%s... ", name(t)))
+				})
 			runOne(t, function (err) {
 				if (err) {
 					numFailures++


### PR DESCRIPTION
I messed this up in earlier PRs, so the output looked quite ugly (each passed test was 2 lines at least), but this should be working in at least Nodejs 0.12 and IOjs 1.6.3.
